### PR TITLE
Provide interactive online version of examples with Binder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. image:: https://mybinder.org/badge.svg :target: https://mybinder.org/v2/gh/nengo/nengo-examples/master
+
 **************
 Nengo examples
 **************

--- a/htbab_tutorials/ch1-singleneuron.ipynb
+++ b/htbab_tutorials/ch1-singleneuron.ipynb
@@ -83,8 +83,8 @@
    },
    "outputs": [],
    "source": [
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch1-singleneuron.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch1-singleneuron.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch2-scalars.ipynb
+++ b/htbab_tutorials/ch2-scalars.ipynb
@@ -80,8 +80,8 @@
    },
    "outputs": [],
    "source": [
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch2-scalars.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch2-scalars.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch2-vectors.ipynb
+++ b/htbab_tutorials/ch2-vectors.ipynb
@@ -104,8 +104,8 @@
    },
    "outputs": [],
    "source": [
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch2-vectors.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch2-vectors.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch3-addition.ipynb
+++ b/htbab_tutorials/ch3-addition.ipynb
@@ -122,8 +122,8 @@
    },
    "outputs": [],
    "source": [
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch3-addition.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch3-addition.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch3-arbitrary-linear.ipynb
+++ b/htbab_tutorials/ch3-arbitrary-linear.ipynb
@@ -92,8 +92,8 @@
    "outputs": [],
    "source": [
     "# Import the nengo_gui visualizer to run and visualize the model.\n",
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch3-arbitrary-linear.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch3-arbitrary-linear.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch3-nonlinear.ipynb
+++ b/htbab_tutorials/ch3-nonlinear.ipynb
@@ -110,8 +110,8 @@
    "outputs": [],
    "source": [
     "# Import the nengo_gui visualizer to run and visualize the model.\n",
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch3-nonlinear.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch3-nonlinear.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch4-structure.ipynb
+++ b/htbab_tutorials/ch4-structure.ipynb
@@ -322,8 +322,8 @@
    },
    "outputs": [],
    "source": [
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch4-structure.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch4-structure.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch5-question-control.ipynb
+++ b/htbab_tutorials/ch5-question-control.ipynb
@@ -285,8 +285,8 @@
    },
    "outputs": [],
    "source": [
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch5-question-control.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch5-question-control.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch5-question-memory.ipynb
+++ b/htbab_tutorials/ch5-question-memory.ipynb
@@ -321,8 +321,8 @@
    },
    "outputs": [],
    "source": [
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch5-question-memory.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch5-question-memory.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch5-question.ipynb
+++ b/htbab_tutorials/ch5-question.ipynb
@@ -314,8 +314,8 @@
    },
    "outputs": [],
    "source": [
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch5-question.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch5-question.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch6-learn.ipynb
+++ b/htbab_tutorials/ch6-learn.ipynb
@@ -110,8 +110,8 @@
    "outputs": [],
    "source": [
     "# Import the nengo_gui visualizer to run and visualize the model.\n",
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch6-learn.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch6-learn.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch7-spa-sequence-routed-cleanup-all.ipynb
+++ b/htbab_tutorials/ch7-spa-sequence-routed-cleanup-all.ipynb
@@ -127,8 +127,8 @@
    "outputs": [],
    "source": [
     "# Import the nengo_gui visualizer to run and visualize the model.\n",
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch7-spa-sequence-routed-cleanup-all.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch7-spa-sequence-routed-cleanup-all.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch7-spa-sequence-routed-cleanup.ipynb
+++ b/htbab_tutorials/ch7-spa-sequence-routed-cleanup.ipynb
@@ -117,8 +117,8 @@
    "outputs": [],
    "source": [
     "# Import the nengo_gui visualizer to run and visualize the model.\n",
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch7-spa-sequence-routed-cleanup.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch7-spa-sequence-routed-cleanup.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch7-spa-sequence-routed.ipynb
+++ b/htbab_tutorials/ch7-spa-sequence-routed.ipynb
@@ -100,8 +100,8 @@
    "outputs": [],
    "source": [
     "# Import the nengo_gui visualizer\n",
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch7-spa-sequence-routed.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch7-spa-sequence-routed.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch7-spa-sequence.ipynb
+++ b/htbab_tutorials/ch7-spa-sequence.ipynb
@@ -105,8 +105,8 @@
    "outputs": [],
    "source": [
     "# Import the nengo_gui visualizer to run and visualize the model.\n",
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch7-spa-sequence.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch7-spa-sequence.py.cfg\")"
    ]
   },
   {

--- a/htbab_tutorials/ch8-2d-decision-integrator.ipynb
+++ b/htbab_tutorials/ch8-2d-decision-integrator.ipynb
@@ -106,8 +106,8 @@
    "outputs": [],
    "source": [
     "# Import the nengo_gui visualizer to run and visualize the model.\n",
-    "from nengo_gui.ipython import IPythonViz\n",
-    "IPythonViz(model, \"ch8-2d-decision-integrator.py.cfg\")"
+    "from nengo_gui.jupyter import InlineGUI\n",
+    "InlineGUI(model, \"ch8-2d-decision-integrator.py.cfg\")"
    ]
   },
   {

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,1 @@
+jupyter serverextension enable nengo_gui.jupyter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+matplotlib
+nengo>=2.3
+nengo-dl>=0.5.1
+-e git+git://github.com/nengo/nengo-gui.git@jupyter-tunnel#egg=nengo_gui


### PR DESCRIPTION
This is intended as a proof-of-concept, but I could very well see this being merged.

This essentially adds configuration files for Binder that allow to run the example notebooks online (interactively!) which makes it much less effort to try Nengo. Note that this relies nengo/nengo-gui#921 (I am explicitly referencing the corresponding branch in the `requirements.txt` for Binder. Of course, ideally we merge that PR and depend on a release version of Nengo GUI.

Note that I updated the IpythonViz/InlineGUI import/call in the HTBAB tutorials to reflect changes in the Nengo GUI PR.