### PR TITLE
Get CIFAR10 notebook working with old versions

### DIFF
--- a/loihi-dl/cifar10_convnet.ipynb
+++ b/loihi-dl/cifar10_convnet.ipynb
@@ -17,7 +17,7 @@
     "- nengo 2.8.0 (``pip install 'nengo==2.8.0'``)\n",
     "- nengo_dl 1.2.1 (``pip install 'nengo-dl==1.2.1'``)\n",
     "- nengo_extras (``pip install nengo-extras``)\n",
-    "- nengo_loihi dev (``pip install git+https://github.com/nengo/nengo-loihi.git``)"
+    "- nengo_loihi dev (``pip install 'nengo-loihi==0.5.0'``)"
    ]
   },
   {
@@ -33,28 +33,35 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
-    "import nengo\n",
-    "from nengo.utils.compat import is_iterable\n",
-    "import nengo_dl\n",
-    "from nengo_dl import SoftLIFRate\n",
-    "from nengo_extras.data import load_cifar10, one_hot_from_labels\n",
-    "import nengo_loihi\n",
-    "from nengo_loihi.conv import (\n",
-    "    Conv2D, ImageSlice, ImageShape, split_transform)\n",
     "import numpy as np\n",
     "import tensorflow as tf\n",
     "\n",
+    "import nengo\n",
     "if nengo.__version__ != '2.8.0':\n",
     "    nengo_version = nengo.__version__\n",
     "    nengo = None\n",
     "    raise ImportError(\"Nengo version is not correct (must be 2.8.0, got %s)\"\n",
     "                      % nengo_version)\n",
     "\n",
+    "import nengo_dl\n",
     "if tuple(nengo_dl.__version__.split('.')[:3]) != ('1', '2', '1'):\n",
     "    nengo_dl_version = nengo_dl.__version__\n",
     "    nengo_dl = None\n",
     "    raise ImportError(\"nengo_dl version is not correct (must be 1.2.1, got %s)\"\n",
-    "                      % nengo_dl_version)"
+    "                      % nengo_dl_version)\n",
+    "\n",
+    "import nengo_loihi\n",
+    "if nengo_loihi.__version__ != '0.5.0':\n",
+    "    nengo_version = nengo.__version__\n",
+    "    nengo_loihi = None\n",
+    "    raise ImportError(\"NengoLoihi version is not correct (must be 0.5.0, got %s)\"\n",
+    "                      % nengo_loihi.__version__)\n",
+    "\n",
+    "from nengo.utils.compat import is_iterable\n",
+    "from nengo_dl import SoftLIFRate\n",
+    "from nengo_extras.data import load_cifar10, one_hot_from_labels\n",
+    "from nengo_loihi.conv import (\n",
+    "    Conv2D, ImageSlice, ImageShape, split_transform)"
    ]
   },
   {
@@ -422,13 +429,13 @@
     "    dict(layer_func=TfConv2d('layer1', 4, kernel_size=1),\n",
     "         neuron_type=nengo.RectifiedLinear(amplitude=amp),\n",
     "         on_chip=False, no_min_rate=True),\n",
-    "    dict(layer_func=TfConv2d('layer2', 64, strides=2), \n",
+    "    dict(layer_func=TfConv2d('layer2', 64, strides=2),\n",
     "         neuron_type=neuron_type),\n",
-    "    dict(layer_func=TfConv2d('layer3', 96), \n",
+    "    dict(layer_func=TfConv2d('layer3', 96),\n",
     "         neuron_type=neuron_type),\n",
-    "    dict(layer_func=TfConv2d('layer4', 128, strides=2), \n",
+    "    dict(layer_func=TfConv2d('layer4', 128, strides=2),\n",
     "         neuron_type=neuron_type),\n",
-    "    dict(layer_func=TfConv2d('layer5', 128, kernel_size=1), \n",
+    "    dict(layer_func=TfConv2d('layer5', 128, kernel_size=1),\n",
     "         neuron_type=neuron_type),\n",
     "    dict(layer_func=TfDense('layer_out', 10)),\n",
     "]\n",
@@ -554,7 +561,7 @@
     "        # compute output range\n",
     "        outs = get_outputs(sim, rate_inputs, out_p)\n",
     "        print(\"Output range: min=%0.3f, 1st=%0.3f, 99th=%0.3f, max=%0.3f\" % (\n",
-    "            outs.min(), np.percentile(outs, 1), np.percentile(outs, 99), \n",
+    "            outs.min(), np.percentile(outs, 1), np.percentile(outs, 99),\n",
     "            outs.max()))\n",
     "        ann_out_min = np.percentile(outs, 1)\n",
     "        ann_out_max = np.percentile(outs, 99)\n",
@@ -674,9 +681,9 @@
    "source": [
     "## Run the spiking neural network on Loihi\n",
     "\n",
-    "Now, we run the spiking model on Loihi (or in the emulator if ``nxsdk`` is \n",
-    "not installed). For demonstration purposes, we only run 10 examples, but \n",
-    "feel free to run 100 or more examples if you wish to get a better idea of \n",
+    "Now, we run the spiking model on Loihi (or in the emulator if ``nxsdk`` is\n",
+    "not installed). For demonstration purposes, we only run 10 examples, but\n",
+    "feel free to run 100 or more examples if you wish to get a better idea of\n",
     "the network accuracy."
    ]
   },
@@ -724,7 +731,7 @@
     "plt.figure(figsize=(12, 6))\n",
     "\n",
     "plt.subplot(2, 1, 1)\n",
-    "images = (X_test if X_shape.channels_last \n",
+    "images = (X_test if X_shape.channels_last\n",
     "          else np.transpose(X_test, (0, 2, 3, 1)))\n",
     "ni, nj, nc = images[0].shape\n",
     "allimage = np.zeros((ni, nj*n_presentations, nc))\n",
@@ -746,22 +753,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/loihi-dl/requirements.txt
+++ b/loihi-dl/requirements.txt
@@ -4,4 +4,4 @@ tensorflow-gpu==1.12.0
 nengo==2.8.0
 nengo-dl==1.2.1
 nengo-extras==0.3.0
-git+https://github.com/nengo/nengo-loihi.git
+nengo-loihi==0.5.0


### PR DESCRIPTION
We had a number of versions already locked, but were using the dev version of nengo_loihi, which has changed. I've now fixed this at 0.5.0, which seems to work well.

Also ran `devscripts/clearoutputs.py` on the notebook, which has cleaned it up a bit.